### PR TITLE
Fix Docker import path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,14 @@
 FROM python:3.12-slim
 WORKDIR /app
+
+# Ensure the application package is importable by adding the `src` directory
+# to the Python path. This allows the `sdc` module to be resolved when
+# launching Uvicorn.
+ENV PYTHONPATH=/app/src
+
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
+
 COPY src ./src
+
 CMD ["uvicorn", "sdc.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- ensure `sdc` package is importable by adding `/app/src` to `PYTHONPATH`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687463a294a4832cab619b9880aa4675