### PR TITLE
Add NAS music library support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,15 @@ services:
     image: ghcr.io/rudyscoggins/songduplicatechecker:latest
     build: .
     user: "1000:1000"
+    restart: unless-stopped
     environment:
       DATA_DIR: /data
+      NAS_PATH: /music
     ports:
       - "5443:8000"
     volumes:
       - ./data:/data
-      - /home/pi/NAS/music/SongDuplicateChecker:/music
+      - /home/pi/NAS/music/Elysium:/music
     labels:
       - com.centurylinklabs.watchtower.scope=songduplicatechecker
   watchtower:

--- a/src/sdc/main.py
+++ b/src/sdc/main.py
@@ -10,7 +10,11 @@ templates = Jinja2Templates(directory=str(utils.TEMPLATES_DIR))
 
 @app.get("/", response_class=HTMLResponse)
 async def read_root(request: Request):
-    return templates.TemplateResponse("index.html", {"request": request})
+    random_file = utils.get_random_music_file()
+    return templates.TemplateResponse(
+        "index.html",
+        {"request": request, "random_file": random_file},
+    )
 
 @app.get("/health")
 async def health():

--- a/src/sdc/templates/index.html
+++ b/src/sdc/templates/index.html
@@ -6,5 +6,6 @@
 </head>
 <body>
     <h1>Hello from SDC</h1>
+    <p>Random music file: {{ random_file }}</p>
 </body>
 </html>

--- a/src/sdc/utils.py
+++ b/src/sdc/utils.py
@@ -1,9 +1,25 @@
 from pathlib import Path
+import os
+import random
 
 BASE_DIR = Path(__file__).resolve().parent
 TEMPLATES_DIR = BASE_DIR / "templates"
+
+# Directory that contains music files mounted from the NAS.
+MUSIC_DIR = Path(os.getenv("NAS_PATH", "/music"))
 
 def check_duplicate(song_path: Path) -> bool:
     """Placeholder for duplicate check logic."""
     # TODO: implement duplicate check
     return False
+
+
+def get_random_music_file() -> str:
+    """Return the name of a random music file from ``MUSIC_DIR``.
+
+    If no files are found, a message stating so is returned.
+    """
+    files = [p.name for p in MUSIC_DIR.rglob("*") if p.is_file()]
+    if not files:
+        return "No music files found"
+    return random.choice(files)


### PR DESCRIPTION
## Summary
- mount NAS music library and expose `NAS_PATH` in docker-compose
- show a random music file on the main page
- add utility helper to pick random file

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687575268918832cbef4fd267a5449d5