### PR TITLE
Display build timestamp in footer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM python:3.12-slim
+ARG BUILD_TIMESTAMP
+ENV BUILD_TIMESTAMP=${BUILD_TIMESTAMP:-unknown}
 WORKDIR /app
 
 # Ensure the application package is importable by adding the `src` directory

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # SongDuplicateChecker
+
+This project displays the timestamp of the container build so you can tell
+when the site was last updated. When building the Docker image, supply a
+`BUILD_TIMESTAMP` argument (in ISO format) or it will default to `unknown`.

--- a/src/sdc/main.py
+++ b/src/sdc/main.py
@@ -12,12 +12,14 @@ templates = Jinja2Templates(directory=str(utils.TEMPLATES_DIR))
 async def read_root(request: Request):
     random_file = utils.get_random_music_file()
     diagnostics = utils.get_nas_diagnostics()
+    build_timestamp = utils.get_build_timestamp()
     return templates.TemplateResponse(
         "index.html",
         {
             "request": request,
             "random_file": random_file,
             "diagnostics": diagnostics,
+            "build_timestamp": build_timestamp,
         },
     )
 

--- a/src/sdc/templates/index.html
+++ b/src/sdc/templates/index.html
@@ -8,5 +8,8 @@
     <h1>Hello from SDC</h1>
     <p>Random music file: {{ random_file }}</p>
     <p>{{ diagnostics }}</p>
+    <footer style="margin-top: 2em; font-size: 0.9em; color: #666;">
+        Build timestamp: {{ build_timestamp }}
+    </footer>
 </body>
 </html>

--- a/src/sdc/utils.py
+++ b/src/sdc/utils.py
@@ -8,6 +8,11 @@ TEMPLATES_DIR = BASE_DIR / "templates"
 # Directory that contains music files mounted from the NAS.
 MUSIC_DIR = Path(os.getenv("NAS_PATH", "/music"))
 
+# Build timestamp provided at Docker image creation time. If not set,
+# defaults to "unknown". This is used to display when the running
+# container was built/deployed.
+BUILD_TIMESTAMP = os.getenv("BUILD_TIMESTAMP", "unknown")
+
 
 def _list_music_files() -> list[Path]:
     """Return a list of all files under ``MUSIC_DIR`` recursively."""
@@ -44,3 +49,8 @@ def get_random_music_file() -> str:
     if not files:
         return "No music files found"
     return random.choice([f.name for f in files])
+
+
+def get_build_timestamp() -> str:
+    """Return the build/deploy timestamp for the running container."""
+    return BUILD_TIMESTAMP


### PR DESCRIPTION
## Summary
- show container build timestamp in template
- expose build timestamp via utils helper
- add build timestamp build arg to Dockerfile
- document build timestamp usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687586c61fec832c8ccfd2584ce6a9c0