### PR TITLE
Fix build script quoting

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,10 @@
 This project displays the timestamp of the container build so you can tell
 when the site was last updated. When building the Docker image, supply a
 `BUILD_TIMESTAMP` argument (in ISO format) or it will default to `unknown`.
+
+To build the Docker image with the current time automatically, run the
+`build.sh` script:
+
+```bash
+./build.sh
+```

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Build the SongDuplicateChecker Docker image with a build timestamp.
+set -e
+
+docker build \
+  --build-arg BUILD_TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  -t ghcr.io/rudyscoggins/songduplicatechecker:latest "$@" .


### PR DESCRIPTION
## Summary
- fix quoting in build.sh to pass build timestamp correctly
- retain README instructions for building with timestamp

## Testing
- `bash -n build.sh`
- `python -m compileall src`


------
https://chatgpt.com/codex/tasks/task_e_6875896ee13c832cbf3da672b2563b1e