### PR TITLE
Align music library config with SongRipper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,27 @@
 # SongDuplicateChecker
 
-This project displays the timestamp of the container build so you can tell
-when the site was last updated. When building the Docker image, supply a
-`BUILD_TIMESTAMP` argument (in ISO format) or it will default to `unknown`.
+SongDuplicateChecker is a small FastAPI service that reads from the same music
+library used by [SongRipper](https://github.com/rudyscoggins/SongRipper).  The
+application simply reports a random file from the library and when the running
+container was built.
 
-To build the Docker image with the current time automatically, run the
-`build.sh` script:
+## Running with Docker
+
+Use the provided `docker-compose.yml` to build and start the service.  It
+mounts your music collection under `/music` and exposes the app on port `5443`.
 
 ```bash
-./build.sh
+docker compose up --build
 ```
+
+## Environment Variables
+
+- `DATA_DIR` – directory for any application data (default: `/data`).
+- `NAS_PATH` – path to the music library inside the container (default:
+  `/music`).
+
+These can be customised in `docker-compose.yml` or when starting the container
+manually.
+
+The `build.sh` script sets a `BUILD_TIMESTAMP` argument so the web page can show
+when the image was created.

--- a/src/sdc/settings.py
+++ b/src/sdc/settings.py
@@ -1,0 +1,5 @@
+import os
+from pathlib import Path
+
+DATA_DIR = Path(os.getenv("DATA_DIR", "/data"))
+NAS_PATH = Path(os.getenv("NAS_PATH", "/music"))

--- a/src/sdc/utils.py
+++ b/src/sdc/utils.py
@@ -2,11 +2,13 @@ from pathlib import Path
 import os
 import random
 
+from . import settings
+
 BASE_DIR = Path(__file__).resolve().parent
 TEMPLATES_DIR = BASE_DIR / "templates"
 
 # Directory that contains music files mounted from the NAS.
-MUSIC_DIR = Path(os.getenv("NAS_PATH", "/music"))
+MUSIC_DIR = settings.NAS_PATH
 
 # Build timestamp provided at Docker image creation time. If not set,
 # defaults to "unknown". This is used to display when the running


### PR DESCRIPTION
## Summary
- add a minimal `settings` module mirroring SongRipper
- reference `settings.NAS_PATH` in utils
- document environment variables and Docker usage

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877fe7764a0832cb26a8b7326932d07